### PR TITLE
Threshold 조회 및 이상 탐지 로직 초안 구현, Entity 명명 이슈 수정

### DIFF
--- a/src/main/java/kr/cs/interdata/api_backend/config/DataInitializer.java
+++ b/src/main/java/kr/cs/interdata/api_backend/config/DataInitializer.java
@@ -1,0 +1,59 @@
+package kr.cs.interdata.api_backend.config;
+
+import kr.cs.interdata.api_backend.entity.MetricsByType;
+import kr.cs.interdata.api_backend.entity.TargetType;
+import kr.cs.interdata.api_backend.repository.MetricsByTypeRepository;
+import kr.cs.interdata.api_backend.repository.TargetTypeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataInitializer implements CommandLineRunner {
+
+    private final TargetTypeRepository targetTypeRepository;
+    private final MetricsByTypeRepository metricsByTypeRepository;
+
+    @Autowired
+    public DataInitializer(TargetTypeRepository targetTypeRepository,
+                           MetricsByTypeRepository metricsByTypeRepository) {
+        this.targetTypeRepository = targetTypeRepository;
+        this.metricsByTypeRepository = metricsByTypeRepository;
+    }
+
+    @Override
+    public void run(String... args) {
+        // 먼저 host, container 타입 존재 여부 확인
+        TargetType hostType = targetTypeRepository.findByType("host")
+                .orElseGet(() -> targetTypeRepository.save(TargetType.builder().type("host").build()));
+
+        TargetType containerType = targetTypeRepository.findByType("container")
+                .orElseGet(() -> targetTypeRepository.save(TargetType.builder().type("container").build()));
+
+        // 이미 저장된 메트릭은 중복 방지
+        insertMetricIfNotExists(hostType, "cpu", "%", 80.0);
+        insertMetricIfNotExists(hostType, "memory", "%", 80.0);
+        insertMetricIfNotExists(hostType, "disk", "%", 90.0);
+        insertMetricIfNotExists(hostType, "network", "bytes/sec", 100000.0);
+
+        insertMetricIfNotExists(containerType, "cpu", "%", 70.0);
+        insertMetricIfNotExists(containerType, "memory", "%", 70.0);
+        insertMetricIfNotExists(containerType, "disk", "%", 85.0);
+        insertMetricIfNotExists(containerType, "network", "bytes/sec", 50000.0);
+    }
+
+    // 만약 type+name인 정보가 MetricsByType 테이블에 존재하지 않는다면 초기 정보를 넣는 메서드
+    private void insertMetricIfNotExists(TargetType type, String name, String unit, Double threshold) {
+        boolean exists = metricsByTypeRepository.existsByTypeAndMetricName(type, name);
+        if (!exists) {
+            MetricsByType metric = MetricsByType.builder()
+                    .type(type)
+                    .metricName(name)
+                    .unit(unit)
+                    .thresholdValue(threshold)
+                    .build();
+            metricsByTypeRepository.save(metric);
+        }
+    }
+
+}

--- a/src/main/java/kr/cs/interdata/api_backend/config/PropertyConfig.java
+++ b/src/main/java/kr/cs/interdata/api_backend/config/PropertyConfig.java
@@ -1,0 +1,12 @@
+package kr.cs.interdata.api_backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
+
+@Configuration
+@PropertySources({
+        @PropertySource("classpath:properties/env.properties") //env.properties 파일 소스 등록
+})
+public class PropertyConfig {
+}

--- a/src/main/java/kr/cs/interdata/api_backend/controller/ThresholdController.java
+++ b/src/main/java/kr/cs/interdata/api_backend/controller/ThresholdController.java
@@ -1,5 +1,6 @@
 package kr.cs.interdata.api_backend.controller;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,33 +12,39 @@ import kr.cs.interdata.api_backend.dto.*;
 import kr.cs.interdata.api_backend.service.ThresholdService;
 
 @RestController
-@RequestMapping("/api/metrics")
+@RequestMapping("/api")
 public class ThresholdController {
 
     private final ThresholdService thresholdService;
 
+    @Autowired
     public ThresholdController(ThresholdService thresholdService) {
         this.thresholdService = thresholdService;
     }
 
-    @GetMapping("/threshold-setting")
+    @GetMapping("/metrics/threshold-setting")
     public ResponseEntity<?> getThreshold() {
         return ResponseEntity.ok(thresholdService.getThreshold());
     }
 
-    @PostMapping("/threshold-setting")
+    @PostMapping("/metrics/threshold-setting")
     public ResponseEntity<?> setThreshold(@RequestBody ThresholdSetting dto) {
         return ResponseEntity.ok(thresholdService.setThreshold(dto));
     }
 
-    @PostMapping("/threshold-history")
+    @PostMapping("/metrics/threshold-history")
     public ResponseEntity<?> getThresholdHistory(@RequestBody DateforHistory date) {
         return ResponseEntity.ok(thresholdService.getThresholdHistory(date));
     }
 
-    @PostMapping("/threshold-check")
-    public ResponseEntity<?> checkThreshold(@RequestBody ThresholdCheck dto) {
-        return ResponseEntity.ok(thresholdService.checkThreshold(dto));
+    @GetMapping("/metrics/threshold-check")
+    public ResponseEntity<?> checkThreshold() {
+        return ResponseEntity.ok(thresholdService.checkThreshold());
+    }
+
+    @PostMapping("/violation-store")
+    public ResponseEntity<?> storeViolation(@RequestBody StoreViolation dto) {
+        return ResponseEntity.ok(thresholdService.storeViolation(dto));
     }
 
 }

--- a/src/main/java/kr/cs/interdata/api_backend/dto/StoreViolation.java
+++ b/src/main/java/kr/cs/interdata/api_backend/dto/StoreViolation.java
@@ -7,9 +7,9 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class ThresholdCheck {
+public class StoreViolation {
 
-    private String host;    // 메시지를 보낸 호스트
+    private String machineId;    // 메시지를 보낸 호스트/컨테이너의 고유 id
     private String metric;  // 메트릭 이름
     private String value;   // 임계값을 넘은 값
     private LocalDateTime timestamp;    // 임계값을 넘은 시각

--- a/src/main/java/kr/cs/interdata/api_backend/entity/AbnormalMetricLog.java
+++ b/src/main/java/kr/cs/interdata/api_backend/entity/AbnormalMetricLog.java
@@ -24,9 +24,9 @@ public class AbnormalMetricLog {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer number;     // 누적 값
 
-    private String target_id;   // anomaly machine's id
+    private String targetId;   // anomaly machine's id
 
-    private String metric_name; // anomaly metric's name
+    private String metricName; // anomaly metric's name
     private Double value;       // outlier
     private LocalDateTime timestamp;    // anomaly가 생긴 시각
 }

--- a/src/main/java/kr/cs/interdata/api_backend/entity/LatestAbnormalStatus.java
+++ b/src/main/java/kr/cs/interdata/api_backend/entity/LatestAbnormalStatus.java
@@ -27,10 +27,10 @@ public class LatestAbnormalStatus {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer number;     // unique id
 
-    private String target_id;   // anomaly machine's id
-    private String metric_name; // anomaly metric's name
+    private String targetId;   // anomaly machine's id
+    private String metricName; // anomaly metric's name
     private String value;       // outlier
-    private LocalDateTime detected_at;  // anomaly detection time
+    private LocalDateTime detectedAt;  // anomaly detection time
     private boolean resolved;   // 이상값이 해결되지 않았다면 false, 이상값이 해결되었다면 true로 update한다.
 
 }

--- a/src/main/java/kr/cs/interdata/api_backend/entity/MetricsByType.java
+++ b/src/main/java/kr/cs/interdata/api_backend/entity/MetricsByType.java
@@ -1,8 +1,7 @@
 package kr.cs.interdata.api_backend.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 /**
  * - table name : MetricsByType
@@ -20,6 +19,9 @@ import lombok.Setter;
 @Table(name = "MetricsByType")
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class MetricsByType {
 
     @Id
@@ -27,11 +29,11 @@ public class MetricsByType {
     private Integer number; // 누적 값
 
     @ManyToOne
-    @JoinColumn(name = "type_id")
+    @JoinColumn(name = "typeId")
     private TargetType type; // machine's 타입
 
-    private String metric_name; // 메트릭 이름
+    private String metricName; // 메트릭 이름
     private String unit; // 단위
-    private Double threshold_value; // 임계값
+    private Double thresholdValue; // 임계값
 
 }

--- a/src/main/java/kr/cs/interdata/api_backend/entity/MonitoredMachineInventory.java
+++ b/src/main/java/kr/cs/interdata/api_backend/entity/MonitoredMachineInventory.java
@@ -24,9 +24,9 @@ public class MonitoredMachineInventory {
     private String id; // machine unique id (타입+숫자)
 
     @ManyToOne
-    @JoinColumn(name = "type_id")
+    @JoinColumn(name = "typeId")
     private TargetType type; // machine's 타입
 
-    private String machine_id; // machine id (host와 container별 생성된 고유 id)
+    private String machineId; // machine id (host와 container별 생성된 고유 id)
 
 }

--- a/src/main/java/kr/cs/interdata/api_backend/entity/TargetType.java
+++ b/src/main/java/kr/cs/interdata/api_backend/entity/TargetType.java
@@ -1,8 +1,7 @@
 package kr.cs.interdata.api_backend.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.List;
 
@@ -21,6 +20,9 @@ import java.util.List;
 @Table(name = "TargetType")
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class TargetType {
 
     @Id

--- a/src/main/java/kr/cs/interdata/api_backend/repository/LatestAbnormalStatusRepository.java
+++ b/src/main/java/kr/cs/interdata/api_backend/repository/LatestAbnormalStatusRepository.java
@@ -3,5 +3,9 @@ package kr.cs.interdata.api_backend.repository;
 import kr.cs.interdata.api_backend.entity.LatestAbnormalStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LatestAbnormalStatusRepository extends JpaRepository<LatestAbnormalStatus, Integer> {
+
+    Optional<LatestAbnormalStatus> findByTargetIdAndMetricName(String targetId, String metricName);
 }

--- a/src/main/java/kr/cs/interdata/api_backend/repository/MetricsByTypeRepository.java
+++ b/src/main/java/kr/cs/interdata/api_backend/repository/MetricsByTypeRepository.java
@@ -1,6 +1,7 @@
 package kr.cs.interdata.api_backend.repository;
 
 import kr.cs.interdata.api_backend.entity.MetricsByType;
+import kr.cs.interdata.api_backend.entity.TargetType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -12,4 +13,6 @@ public interface MetricsByTypeRepository extends JpaRepository<MetricsByType, In
 
     // type과 metricName으로 엔티티를 찾아주는 메서드
     Optional<MetricsByType> findByType_TypeAndMetricName(String type, String metricName);
+
+    boolean existsByTypeAndMetricName(TargetType type, String metricName);
 }

--- a/src/main/java/kr/cs/interdata/api_backend/repository/MonitoredMachineInventoryRepository.java
+++ b/src/main/java/kr/cs/interdata/api_backend/repository/MonitoredMachineInventoryRepository.java
@@ -1,15 +1,28 @@
 package kr.cs.interdata.api_backend.repository;
 
 import kr.cs.interdata.api_backend.entity.MonitoredMachineInventory;
-import kr.cs.interdata.api_backend.entity.TargetType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface MonitoredMachineInventoryRepository extends JpaRepository<MonitoredMachineInventory, String> {
 
-    @Override
-    Optional<MonitoredMachineInventory> findById(String s);
+    // 타입이 type인 모든 데이터의 수를 가져옴.
+    @Query("SELECT COUNT(m) FROM MonitoredMachineInventory m WHERE m.type.type = :typeName")
+    int countByType(@Param("typeName") String typeName);
 
-    long countByType(TargetType type);
+    // 모든 데이터의 수를 가져옴.
+    @Query("SELECT COUNT(m) FROM MonitoredMachineInventory m")
+    int countAll();
+
+    // type에 따라 displayId 중 최대값을 가져옴
+    @Query("SELECT m.id " +
+            "FROM MonitoredMachineInventory m " +
+            "WHERE m.type = :type AND m.id IS NOT NULL " +
+            "ORDER BY m.id DESC")
+    List<String> findTopIdByType(@Param("type") String type, Pageable pageable);
+
 }

--- a/src/main/java/kr/cs/interdata/api_backend/service/AbnormalDtectionService.java
+++ b/src/main/java/kr/cs/interdata/api_backend/service/AbnormalDtectionService.java
@@ -1,9 +1,14 @@
-package kr.cs.interdata.consumer.service;
+package kr.cs.interdata.api_backend.service;
 
-import kr.cs.interdata.consumer.repository.AbnormalMetricLogRepository;
-import kr.cs.interdata.consumer.repository.LatestAbnormalStatusRepository;
+import kr.cs.interdata.api_backend.entity.AbnormalMetricLog;
+import kr.cs.interdata.api_backend.entity.LatestAbnormalStatus;
+import kr.cs.interdata.api_backend.repository.AbnormalMetricLogRepository;
+import kr.cs.interdata.api_backend.repository.LatestAbnormalStatusRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 public class AbnormalDtectionService {
@@ -19,9 +24,48 @@ public class AbnormalDtectionService {
         this.latestAbnormalStatusRepository = latestAbnormalStatusRepository;
     }
 
-    //이상 로그 저장 -> 둘 다 케이스 나눠서 한꺼번에 저장 혹은 업데이트 -  abnormal, latest 둘 다
-    //abnormal -> add
-    //latest -> add or update
+    /**
+     *  - 이상 로그 저장하는 메서드
+     *  - 데이터를 AbnormalMetricLog에 저장. 동시에 LatestAbnormalStatus에 저장 또는 갱신한다.
+     *
+     * @param id        이상값이 생긴 머신의 고유 id
+     * @param metric    이상값이 생긴 메트릭 이름
+     * @param value     이상값
+     * @param timestamp 이상값이 생긴 시각
+     */
+    public void storeViolation(String id, String metric, String value, LocalDateTime timestamp) {
+        // 1. AbnormalMetricLog 저장
+        AbnormalMetricLog abn = new AbnormalMetricLog();
+
+        abn.setTargetId(id);
+        abn.setMetricName(metric);
+        abn.setValue(Double.valueOf(value));
+        abn.setTimestamp(timestamp);
+        abnormalMetricLogRepository.save(abn);
+
+        // 2. LatestAbnormalStatus 저장 또는 갱신
+        Optional<LatestAbnormalStatus> optional =
+                latestAbnormalStatusRepository.findByTargetIdAndMetricName(id, metric);
+
+        if (optional.isPresent()) {
+            // 이미 존재하면: 업데이트만
+            LatestAbnormalStatus existing = optional.get();
+            existing.setValue(value);
+            existing.setDetectedAt(timestamp);
+            existing.setResolved(false);
+            latestAbnormalStatusRepository.save(existing);
+        } else {
+            // 존재하지 않으면: 새로 저장
+            LatestAbnormalStatus latest_abn = new LatestAbnormalStatus();
+            latest_abn.setTargetId(id);
+            latest_abn.setMetricName(metric);
+            latest_abn.setValue(value);
+            latest_abn.setDetectedAt(timestamp);
+            latest_abn.setResolved(false);
+            latestAbnormalStatusRepository.save(latest_abn);
+        }
+    }
+
     //최근 이상 상태 조회 - latestAbnormalStauts
     //(선택)1달 이상 지난 로그 삭제 -> 둘 다
 }

--- a/src/main/java/kr/cs/interdata/api_backend/service/MachineInventoryService.java
+++ b/src/main/java/kr/cs/interdata/api_backend/service/MachineInventoryService.java
@@ -1,22 +1,77 @@
-package kr.cs.interdata.consumer.service;
+package kr.cs.interdata.api_backend.service;
 
-import kr.cs.interdata.consumer.repository.MonitoredMachineInventoryRepository;
+import kr.cs.interdata.api_backend.entity.MonitoredMachineInventory;
+import kr.cs.interdata.api_backend.entity.TargetType;
+import kr.cs.interdata.api_backend.repository.MonitoredMachineInventoryRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class MachineInventoryService {
 
-    private final MonitoredMachineInventoryRepository monitoredMachineInventoryRepository;
+    private final Logger logger = LoggerFactory.getLogger(MonitoringDefinitionService.class);
+
+    public final MonitoredMachineInventoryRepository monitoredMachineInventoryRepository;
 
     @Autowired
     public MachineInventoryService(MonitoredMachineInventoryRepository monitoredMachineInventoryRepository) {
         this.monitoredMachineInventoryRepository = monitoredMachineInventoryRepository;
     }
 
+    // type당 고유 id를 순서대로 생성하는 메서드(ex. host001, container002)
+    public String generateNextId(String type) {
+        Pageable topOne = PageRequest.of(0, 1); // 가장 최근 하나만 가져옴
+        List<String> topIds = monitoredMachineInventoryRepository.findTopIdByType(type, topOne);
+
+        int nextNumber = 1;
+        if (!topIds.isEmpty()) {
+            String lastId = topIds.get(0); // 예: host003
+            String numberPart = lastId.replace(type, ""); // "003"
+            try {
+                nextNumber = Integer.parseInt(numberPart) + 1;
+            } catch (NumberFormatException e) {
+                throw new RuntimeException("id 형식이 잘못되었습니다(ex. host013, container002): " + lastId);
+            }
+        }
+
+        return String.format("%s%03d", type, nextNumber); // host004
+    }
+
     // 머신 등록 - add
-    // 머신 조회
-    // 머신 삭제
+    public void addMachine(String type, String machine_id) {
+        TargetType targetType = new TargetType();
+        targetType.setType(type);
+
+        MonitoredMachineInventory machine = new MonitoredMachineInventory();
+        String id = generateNextId(type);
+        machine.setId(id);
+        machine.setType(targetType);
+        machine.setMachineId(machine_id);
+
+        monitoredMachineInventoryRepository.save(machine);
+
+        logger.info("머신을 성공적으로 등록하였습니다: {} -> {}, {}", id, type, machine_id);
+    }
+
     // 머신 모든 숫자 조회
+    public int retrieveAllMachineNumber() {
+        int result = 0;
+        result = monitoredMachineInventoryRepository.countAll();
+
+        return result;
+    }
+
     // "type"을 입력한 타입의 머신 총 숫자 조회
+    public int retrieveMachineNumberByType(String type) {
+        int result = 0;
+        result = monitoredMachineInventoryRepository.countByType(type);
+
+        return result;
+    }
 }

--- a/src/main/java/kr/cs/interdata/api_backend/service/MonitoringDefinitionService.java
+++ b/src/main/java/kr/cs/interdata/api_backend/service/MonitoringDefinitionService.java
@@ -1,11 +1,11 @@
-package kr.cs.interdata.consumer.service;
+package kr.cs.interdata.api_backend.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.cs.interdata.consumer.entity.MetricsByType;
-import kr.cs.interdata.consumer.entity.TargetType;
-import kr.cs.interdata.consumer.repository.MetricsByTypeRepository;
-import kr.cs.interdata.consumer.repository.TargetTypeRepository;
+import kr.cs.interdata.api_backend.entity.MetricsByType;
+import kr.cs.interdata.api_backend.entity.TargetType;
+import kr.cs.interdata.api_backend.repository.MetricsByTypeRepository;
+import kr.cs.interdata.api_backend.repository.TargetTypeRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,18 +35,19 @@ public class MonitoringDefinitionService {
 
     // 타입 등록 - targetType
     public void registerType(String type) {
-        TargetType targetType = null;
+        TargetType targetType = new TargetType();
         targetType.setType(type);
         targetTypeRepository.save(targetType);
 
         logger.info("Register type "+type+" successfully.");
     }
 
+    // 새로운 메트릭 등록
     public void saveMetric(String metricName, String unit, Double threshold){
-        MetricsByType metric = null;
-        metric.setMetric_name(metricName);
+        MetricsByType metric = new MetricsByType();
+        metric.setMetricName(metricName);
         metric.setUnit(unit);
-        metric.setThreshold_value(threshold);
+        metric.setThresholdValue(threshold);
         metricsByTypeRepository.save(metric);
 
         logger.info("Save new metric : " + metricName + "(" + unit + ")");

--- a/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
+++ b/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
@@ -60,8 +60,7 @@ public class ThresholdService {
      *      ex. <host, <cpu, 80.0>>, <container,<memory,95.0>>, ...
      */
     public Object checkThreshold() {
-        // Map을 선언한다.
-        // Key는 'host' 또는 'container', Value는 해당 타입에 대한 메트릭들.
+        // Key는 'host' 또는 'container', Value는 해당 타입에 대한 메트릭들에 대한 Map을 선언한다.
         Map<String, Map<String, Double>> resultMap = new ConcurrentHashMap<>();
 
         // 모든 MetricsByType 데이터를 가져옴.
@@ -76,6 +75,7 @@ public class ThresholdService {
             Map<String, Double> metricMap = resultMap.getOrDefault(typeKey, new ConcurrentHashMap<>());
             metricMap.put(metric.getMetricName(), metric.getThresholdValue());
 
+            //결과 Map
             resultMap.put(typeKey, metricMap);
         }
 

--- a/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
+++ b/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
@@ -96,6 +96,7 @@ public class ThresholdService {
      *        - timestamp: 임계값을 넘은 시각
      */
     public String storeViolation(StoreViolation dto) {
+        //이상값이 생긴 로그를 저장한다.
         abnormalDtectionService.storeViolation(
                 dto.getMachineId(),
                 dto.getMetric(),
@@ -103,6 +104,7 @@ public class ThresholdService {
                 dto.getTimestamp()
         );
 
+        //단, request에 대한 응답값은 없다.
         return "ok";
     }
 }

--- a/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
+++ b/src/main/java/kr/cs/interdata/api_backend/service/ThresholdService.java
@@ -1,12 +1,29 @@
 package kr.cs.interdata.api_backend.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import kr.cs.interdata.api_backend.dto.DateforHistory;
-import kr.cs.interdata.api_backend.dto.ThresholdCheck;
+import kr.cs.interdata.api_backend.dto.StoreViolation;
 import kr.cs.interdata.api_backend.dto.ThresholdSetting;
+import kr.cs.interdata.api_backend.entity.MetricsByType;
+import kr.cs.interdata.api_backend.repository.MetricsByTypeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
+@Service
 public class ThresholdService {
+
+    private final AbnormalDtectionService abnormalDtectionService;
+    private final MetricsByTypeRepository metricsByTypeRepository;
+
+    @Autowired
+    public ThresholdService(AbnormalDtectionService abnormalDtectionService,
+                            MetricsByTypeRepository metricsByTypeRepository) {
+        this.abnormalDtectionService = abnormalDtectionService;
+        this.metricsByTypeRepository = metricsByTypeRepository;
+    }
 
     // 1. 현재 설정된 임계값을 조회
     public Object getThreshold() {
@@ -34,10 +51,58 @@ public class ThresholdService {
         return List.of(); // 실제로는 이력 DTO 리스트
     }
 
-    // 4. threshold 조회 
-    //    -> consumer에서 임계값을 조회해 임계값을 넘어선 데이터가 있을 시, 이를 처리하는 용도
-    public Object checkThreshold(ThresholdCheck dto) {
-        // TODO: DB에서 임계값 조회 및 경고 메세지 전달
-        return new Object(); // 실제로는 어떤 값을 보내지 않고 이 폴더 내에서 처리 -> 임계값을 넘어선다면 클라이언트으로 경고를 보냄.
+    /**
+     *  4. threshold 조회
+     *  -> MetricsByType 테이블의 모든 값을 조회해, 
+     *      모든 타입의 모든 metric의 threshold를 Map의 형태로 저장하여 return한다.
+     * 
+     * @return Map<type(String), Map<metric_name(String), threshold(Double)>> resultMap
+     *      ex. <host, <cpu, 80.0>>, <container,<memory,95.0>>, ...
+     */
+    public Object checkThreshold() {
+        // Map을 선언한다.
+        // Key는 'host' 또는 'container', Value는 해당 타입에 대한 메트릭들.
+        Map<String, Map<String, Double>> resultMap = new ConcurrentHashMap<>();
+
+        // 모든 MetricsByType 데이터를 가져옴.
+        List<MetricsByType> metricsList = metricsByTypeRepository.findAll();
+
+        // 데이터를 순차적으로 처리하여 결과 Map에 추가한다.
+        for (MetricsByType metric : metricsList) {
+            // type (host 또는 container)을 key로 사용
+            String typeKey = metric.getType().getType();
+
+            // 메트릭 이름과 threshold 값을 Map에 추가
+            Map<String, Double> metricMap = resultMap.getOrDefault(typeKey, new ConcurrentHashMap<>());
+            metricMap.put(metric.getMetricName(), metric.getThresholdValue());
+
+            resultMap.put(typeKey, metricMap);
+        }
+
+        // 최종적으로 resultMap을 반환
+        return resultMap;
+    }
+
+    /**
+     * TODO: 테스트 전 메서드 - service/ThresholdService.java - 5.threshold 조회
+     *
+     *  5. threshold 조회
+     *    -> consumer에서 임계값을 조회해 임계값을 넘어선 데이터가 있을 시, 이를 db에 저장한다.
+     *    -> db : AbnormalMetricLog, LatestAbnormalStatus
+     * @param dto
+     *        - type     : 메시지를 보낸 호스트
+     *        - metric   : 메트릭 이름
+     *        - value    : 임계값을 넘은 값
+     *        - timestamp: 임계값을 넘은 시각
+     */
+    public String storeViolation(StoreViolation dto) {
+        abnormalDtectionService.storeViolation(
+                dto.getMachineId(),
+                dto.getMetric(),
+                dto.getValue(),
+                dto.getTimestamp()
+        );
+
+        return "ok";
     }
 }


### PR DESCRIPTION
1. Threshold 조회 기능 구현
- ThresholdService에서 MetricsByType 테이블의 모든 threshold 값을 조회하여,
  모든 타입의 metric을 Map<String, Map<String, Double>> 형태로 반환하도록 처리했습니다.
  (이 기능은 "consumer"에서 요청받아 수행 후 반환하는 기능입니다.)

2. 이상 탐지 로직 초안 작성 (아직 테스트 전)
- consumer 측에서 threshold를 조회하여, 전달받은 metric이 임계값을 초과했는지 판별합니다.
- 초과한 경우, AbnormalMetricLog 및 LatestAbnormalStatus 테이블에 이상 로그를 저장하는 로직을 구현했습니다.
- 아직 테스트는 완료되지 않았으며, 추후 테스트 예정입니다.

3. Entity 명명 오류 수정 및 관련 repository 정비
- Entity 변수명에서 발생한 문제를 해결하고,
  이에 따라 repository 코드를 함께 정비하여 정상 작동하도록 수정했습니다.
- 또한, 앱 시작 후 초기 Create시, MetricsByType과 TargetType 테이블에 초기 데이터를 넣을 수 있도록 구현했습니다.

4. 아직 웸과 통신하는 API는 구현하지 않았습니다. 
5. 그렇지만 골격은 만들어 놓았으니 service/ThresholdService.java에서 메세드별로 추후 구현 바랍니다.
